### PR TITLE
Update Fiat 500e generations: Add Wikipedia references and correct Gen 1 start year

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Fiat 500e
 
+This repository contains signal set configurations for the Fiat 500e, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Fiat 500e.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,6 +1,10 @@
+references:
+  - "https://en.wikipedia.org/wiki/Fiat_500e"
+  - "https://en.wikipedia.org/wiki/Fiat_500_(2007)"
+
 generations:
   - name: "First Generation (Type 312)"
-    start_year: 2013
+    start_year: 2012
     end_year: 2019
     description: "The original Fiat 500e was an electric variant of the conventional 500, developed primarily as a compliance car to meet California's zero-emission vehicle mandate. Despite sharing the body and most design elements with the gasoline-powered 500, it featured significant engineering modifications to accommodate the electric powertrain. Powered by a 24 kWh lithium-ion battery and an 83 kW (111 HP) electric motor driving the front wheels, it offered an EPA-rated range of 87 miles. Performance was surprisingly spirited with 0-60 mph acceleration in about 8.4 seconds. The interior maintained the retro-inspired design of the standard 500 but with model-specific instrumentation displaying charge status and energy flow. Limited primarily to California and Oregon markets, the first-generation 500e was not a commercial focus for Fiat, with then-CEO Sergio Marchionne famously asking customers not to buy it due to the significant financial losses on each unit sold. Despite this, it received positive reviews for its driving dynamics and character, often considered one of the more enjoyable early mainstream EVs to drive."
 


### PR DESCRIPTION
- Added references array with Wikipedia links for Fiat 500e and Fiat 500 (2007)
- Corrected first generation start year from 2013 to 2012 (production began December 2012)
- Updated README.md with proper title and standard template
- Wikipedia confirms Gen 1 (Type 312): December 2012-June 2019
- Wikipedia confirms Gen 2 (Type 332): February 2020-present

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
